### PR TITLE
Here is three commits to solve #5 issue 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 script: coverage run --source field_history runtests.py tests
 
 env:
+  - DJANGO=1.7.5
   - DJANGO=1.8.8
   - DJANGO=1.9.2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
       env: DJANGO=1.9.2
     - python: 3.3
       env: DJANGO=1.9.2
+    - python: 3.5
+      env: DJANGO=1.7.5
 
 after_success:
   - coveralls

--- a/field_history/json_nested_serializer.py
+++ b/field_history/json_nested_serializer.py
@@ -10,15 +10,19 @@ from __future__ import unicode_literals
 
 import warnings
 
-from django.utils.deprecation import RemovedInDjango19Warning
 from django.core.serializers.json import Serializer as JsonSerializer
 from django.core.serializers.json import Deserializer
 from django.utils import six
 
+try:
+    from django.utils.deprecation import RemovedInDjango19Warning
+except ImportError:
+    RemovedInDjango19Warning = None
+
 
 class Serializer(JsonSerializer):
     """
-    Convert a queryset to JSON.
+    Convert a queryset to JSON.q
     """
     def serialize(self, queryset, **options):
         """
@@ -29,7 +33,7 @@ class Serializer(JsonSerializer):
         self.stream = options.pop("stream", six.StringIO())
         self.selected_fields = options.pop("fields", None)
         self.use_natural_keys = options.pop("use_natural_keys", False)
-        if self.use_natural_keys:
+        if self.use_natural_keys and RemovedInDjango19Warning is not None:
             warnings.warn("``use_natural_keys`` is deprecated; use ``use_natural_foreign_keys`` instead.",
                 RemovedInDjango19Warning)
         self.use_natural_foreign_keys = options.pop('use_natural_foreign_keys', False) or self.use_natural_keys

--- a/field_history/json_nested_serializer.py
+++ b/field_history/json_nested_serializer.py
@@ -1,0 +1,157 @@
+"""
+Serialize data to/from JSON
+Only one change comparing to Django build-in json serializer: obj.local_fields -> obj.fields for supporting
+nested models, parent fields are included to output
+"""
+
+# Avoid shadowing the standard library json module
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import warnings
+import datetime
+import decimal
+import json
+import sys
+
+from django.utils.deprecation import RemovedInDjango19Warning
+from django.core.serializers.base import DeserializationError
+from django.core.serializers.python import Serializer as PythonSerializer
+from django.core.serializers.python import Deserializer as PythonDeserializer
+from django.utils import six
+from django.utils.timezone import is_aware
+
+
+class Serializer(PythonSerializer):
+    """
+    Convert a queryset to JSON.
+    """
+    internal_use_only = False
+
+    def serialize(self, queryset, **options):
+        """
+        Serialize a queryset.
+        """
+        self.options = options
+
+        self.stream = options.pop("stream", six.StringIO())
+        self.selected_fields = options.pop("fields", None)
+        self.use_natural_keys = options.pop("use_natural_keys", False)
+        if self.use_natural_keys:
+            warnings.warn("``use_natural_keys`` is deprecated; use ``use_natural_foreign_keys`` instead.",
+                RemovedInDjango19Warning)
+        self.use_natural_foreign_keys = options.pop('use_natural_foreign_keys', False) or self.use_natural_keys
+        self.use_natural_primary_keys = options.pop('use_natural_primary_keys', False)
+
+        self.start_serialization()
+        self.first = True
+        for obj in queryset:
+            self.start_object(obj)
+            # Use the concrete parent class' _meta instead of the object's _meta
+            # This is to avoid local_fields problems for proxy models. Refs #17717.
+            concrete_model = obj._meta.concrete_model
+            # only one change local_fields -> fields for supporting nested models
+            for field in concrete_model._meta.fields:
+                if field.serialize:
+                    if field.rel is None:
+                        if self.selected_fields is None or field.attname in self.selected_fields:
+                            self.handle_field(obj, field)
+                    else:
+                        if self.selected_fields is None or field.attname[:-3] in self.selected_fields:
+                            self.handle_fk_field(obj, field)
+            for field in concrete_model._meta.many_to_many:
+                if field.serialize:
+                    if self.selected_fields is None or field.attname in self.selected_fields:
+                        self.handle_m2m_field(obj, field)
+            self.end_object(obj)
+            if self.first:
+                self.first = False
+        self.end_serialization()
+        return self.getvalue()
+
+    def start_serialization(self):
+        if json.__version__.split('.') >= ['2', '1', '3']:
+            # Use JS strings to represent Python Decimal instances (ticket #16850)
+            self.options.update({'use_decimal': False})
+        self._current = None
+        self.json_kwargs = self.options.copy()
+        self.json_kwargs.pop('stream', None)
+        self.json_kwargs.pop('fields', None)
+        if self.options.get('indent'):
+            # Prevent trailing spaces
+            self.json_kwargs['separators'] = (',', ': ')
+        self.stream.write("[")
+
+    def end_serialization(self):
+        if self.options.get("indent"):
+            self.stream.write("\n")
+        self.stream.write("]")
+        if self.options.get("indent"):
+            self.stream.write("\n")
+
+    def end_object(self, obj):
+        # self._current has the field data
+        indent = self.options.get("indent")
+        if not self.first:
+            self.stream.write(",")
+            if not indent:
+                self.stream.write(" ")
+        if indent:
+            self.stream.write("\n")
+        json.dump(self.get_dump_object(obj), self.stream,
+                  cls=DjangoJSONEncoder, **self.json_kwargs)
+        self._current = None
+
+    def getvalue(self):
+        # Grand-parent super
+        return super(PythonSerializer, self).getvalue()
+
+
+def Deserializer(stream_or_string, **options):
+    """
+    Deserialize a stream or string of JSON data.
+    """
+    if not isinstance(stream_or_string, (bytes, six.string_types)):
+        stream_or_string = stream_or_string.read()
+    if isinstance(stream_or_string, bytes):
+        stream_or_string = stream_or_string.decode('utf-8')
+    try:
+        objects = json.loads(stream_or_string)
+        for obj in PythonDeserializer(objects, **options):
+            yield obj
+    except GeneratorExit:
+        raise
+    except Exception as e:
+        # Map to deserializer error
+        six.reraise(DeserializationError, DeserializationError(e), sys.exc_info()[2])
+
+
+class DjangoJSONEncoder(json.JSONEncoder):
+    """
+    JSONEncoder subclass that knows how to encode date/time and decimal types.
+    """
+    def default(self, o):
+        # See "Date Time String Format" in the ECMA-262 specification.
+        if isinstance(o, datetime.datetime):
+            r = o.isoformat()
+            if o.microsecond:
+                r = r[:23] + r[26:]
+            if r.endswith('+00:00'):
+                r = r[:-6] + 'Z'
+            return r
+        elif isinstance(o, datetime.date):
+            return o.isoformat()
+        elif isinstance(o, datetime.time):
+            if is_aware(o):
+                raise ValueError("JSON can't represent timezone-aware times.")
+            r = o.isoformat()
+            if o.microsecond:
+                r = r[:12]
+            return r
+        elif isinstance(o, decimal.Decimal):
+            return str(o)
+        else:
+            return super(DjangoJSONEncoder, self).default(o)
+
+# Older, deprecated class name (for backwards compatibility purposes).
+DateTimeAwareJSONEncoder = DjangoJSONEncoder

--- a/field_history/json_nested_serializer.py
+++ b/field_history/json_nested_serializer.py
@@ -9,25 +9,17 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import warnings
-import datetime
-import decimal
-import json
-import sys
 
 from django.utils.deprecation import RemovedInDjango19Warning
-from django.core.serializers.base import DeserializationError
-from django.core.serializers.python import Serializer as PythonSerializer
-from django.core.serializers.python import Deserializer as PythonDeserializer
+from django.core.serializers.json import Serializer as JsonSerializer
+from django.core.serializers.json import Deserializer
 from django.utils import six
-from django.utils.timezone import is_aware
 
 
-class Serializer(PythonSerializer):
+class Serializer(JsonSerializer):
     """
     Convert a queryset to JSON.
     """
-    internal_use_only = False
-
     def serialize(self, queryset, **options):
         """
         Serialize a queryset.
@@ -68,90 +60,3 @@ class Serializer(PythonSerializer):
                 self.first = False
         self.end_serialization()
         return self.getvalue()
-
-    def start_serialization(self):
-        if json.__version__.split('.') >= ['2', '1', '3']:
-            # Use JS strings to represent Python Decimal instances (ticket #16850)
-            self.options.update({'use_decimal': False})
-        self._current = None
-        self.json_kwargs = self.options.copy()
-        self.json_kwargs.pop('stream', None)
-        self.json_kwargs.pop('fields', None)
-        if self.options.get('indent'):
-            # Prevent trailing spaces
-            self.json_kwargs['separators'] = (',', ': ')
-        self.stream.write("[")
-
-    def end_serialization(self):
-        if self.options.get("indent"):
-            self.stream.write("\n")
-        self.stream.write("]")
-        if self.options.get("indent"):
-            self.stream.write("\n")
-
-    def end_object(self, obj):
-        # self._current has the field data
-        indent = self.options.get("indent")
-        if not self.first:
-            self.stream.write(",")
-            if not indent:
-                self.stream.write(" ")
-        if indent:
-            self.stream.write("\n")
-        json.dump(self.get_dump_object(obj), self.stream,
-                  cls=DjangoJSONEncoder, **self.json_kwargs)
-        self._current = None
-
-    def getvalue(self):
-        # Grand-parent super
-        return super(PythonSerializer, self).getvalue()
-
-
-def Deserializer(stream_or_string, **options):
-    """
-    Deserialize a stream or string of JSON data.
-    """
-    if not isinstance(stream_or_string, (bytes, six.string_types)):
-        stream_or_string = stream_or_string.read()
-    if isinstance(stream_or_string, bytes):
-        stream_or_string = stream_or_string.decode('utf-8')
-    try:
-        objects = json.loads(stream_or_string)
-        for obj in PythonDeserializer(objects, **options):
-            yield obj
-    except GeneratorExit:
-        raise
-    except Exception as e:
-        # Map to deserializer error
-        six.reraise(DeserializationError, DeserializationError(e), sys.exc_info()[2])
-
-
-class DjangoJSONEncoder(json.JSONEncoder):
-    """
-    JSONEncoder subclass that knows how to encode date/time and decimal types.
-    """
-    def default(self, o):
-        # See "Date Time String Format" in the ECMA-262 specification.
-        if isinstance(o, datetime.datetime):
-            r = o.isoformat()
-            if o.microsecond:
-                r = r[:23] + r[26:]
-            if r.endswith('+00:00'):
-                r = r[:-6] + 'Z'
-            return r
-        elif isinstance(o, datetime.date):
-            return o.isoformat()
-        elif isinstance(o, datetime.time):
-            if is_aware(o):
-                raise ValueError("JSON can't represent timezone-aware times.")
-            r = o.isoformat()
-            if o.microsecond:
-                r = r[:12]
-            return r
-        elif isinstance(o, decimal.Decimal):
-            return str(o)
-        else:
-            return super(DjangoJSONEncoder, self).default(o)
-
-# Older, deprecated class name (for backwards compatibility purposes).
-DateTimeAwareJSONEncoder = DjangoJSONEncoder

--- a/field_history/management/commands/createinitialfieldhistory.py
+++ b/field_history/management/commands/createinitialfieldhistory.py
@@ -5,7 +5,7 @@ from django.core import serializers
 from django.core.management import BaseCommand
 
 from field_history.models import FieldHistory
-from field_history.tracker import FieldHistoryTracker, SERIALIZER_NAME
+from field_history.tracker import FieldHistoryTracker, get_serializer_name
 
 
 class Command(BaseCommand):
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
                 for obj in model._default_manager.all():
                     for field in list(fields):
-                        data = serializers.serialize(SERIALIZER_NAME,
+                        data = serializers.serialize(get_serializer_name(),
                                                      [obj],
                                                      fields=[field])
                         FieldHistory.objects.create(

--- a/field_history/management/commands/createinitialfieldhistory.py
+++ b/field_history/management/commands/createinitialfieldhistory.py
@@ -5,7 +5,7 @@ from django.core import serializers
 from django.core.management import BaseCommand
 
 from field_history.models import FieldHistory
-from field_history.tracker import FieldHistoryTracker
+from field_history.tracker import FieldHistoryTracker, SERIALIZER_NAME
 
 
 class Command(BaseCommand):
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
                 for obj in model._default_manager.all():
                     for field in list(fields):
-                        data = serializers.serialize('json',
+                        data = serializers.serialize(SERIALIZER_NAME,
                                                      [obj],
                                                      fields=[field])
                         FieldHistory.objects.create(

--- a/field_history/management/commands/renamefieldhistory.py
+++ b/field_history/management/commands/renamefieldhistory.py
@@ -32,9 +32,9 @@ Example:
             help='The new model field name')
 
     def handle(self, *args, **options):
-        model_name = options['model']
-        from_field = options['from_field']
-        to_field = options['to_field']
+        model_name = options.get('model')
+        from_field = options.get('from_field')
+        to_field = options.get('to_field')
 
         if not model_name:
             raise CommandError('--model_name is a required argument')

--- a/field_history/migrations/0001_initial.py
+++ b/field_history/migrations/0001_initial.py
@@ -12,6 +12,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        ('contenttypes', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/field_history/migrations/0001_initial.py
+++ b/field_history/migrations/0001_initial.py
@@ -12,7 +12,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/field_history/migrations/0002_auto_20160413_1824.py
+++ b/field_history/migrations/0002_auto_20160413_1824.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('field_history', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='fieldhistory',
+            options={'get_latest_by': 'date_created'},
+        ),
+        migrations.AlterField(
+            model_name='fieldhistory',
+            name='field_name',
+            field=models.CharField(max_length=500, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/field_history/models.py
+++ b/field_history/models.py
@@ -16,7 +16,7 @@ class FieldHistory(models.Model):
     object_id = models.TextField(db_index=True)
     content_type = models.ForeignKey('contenttypes.ContentType', db_index=True)
     object = GenericForeignKey()
-    field_name = models.CharField(max_length=500)
+    field_name = models.CharField(max_length=500, db_index=True)
     serialized_data = models.TextField()
     date_created = models.DateTimeField(auto_now_add=True, db_index=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)

--- a/field_history/tracker.py
+++ b/field_history/tracker.py
@@ -4,10 +4,13 @@ from copy import deepcopy
 import threading
 
 from django.core import serializers
+from django.conf import settings
 from django.db import models
 from django.utils.functional import curry
 
 from .models import FieldHistory
+
+SERIALIZER_NAME = getattr(settings, 'FIELD_HISTORY_SERIALIZER_NAME', 'json')
 
 
 class FieldInstanceTracker(object):
@@ -92,7 +95,7 @@ class FieldHistoryTracker(object):
             # Create a FieldHistory for all self.fields that have changed
             for field in self.fields:
                 if tracker.has_changed(field) or is_new_object:
-                    data = serializers.serialize('json',
+                    data = serializers.serialize(SERIALIZER_NAME,
                                                  [instance],
                                                  fields=[field])
                     user = self.get_field_history_user(instance)

--- a/field_history/tracker.py
+++ b/field_history/tracker.py
@@ -10,7 +10,9 @@ from django.utils.functional import curry
 
 from .models import FieldHistory
 
-SERIALIZER_NAME = getattr(settings, 'FIELD_HISTORY_SERIALIZER_NAME', 'json')
+
+def get_serializer_name():
+    return getattr(settings, 'FIELD_HISTORY_SERIALIZER_NAME', 'json')
 
 
 class FieldInstanceTracker(object):
@@ -95,7 +97,7 @@ class FieldHistoryTracker(object):
             # Create a FieldHistory for all self.fields that have changed
             for field in self.fields:
                 if tracker.has_changed(field) or is_new_object:
-                    data = serializers.serialize(SERIALIZER_NAME,
+                    data = serializers.serialize(get_serializer_name(),
                                                  [instance],
                                                  fields=[field])
                     user = self.get_field_history_user(instance)

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,13 +8,6 @@ class Pet(models.Model):
     name = models.CharField(max_length=255)
 
 
-class Owner(models.Model):
-    name = models.CharField(max_length=255)
-    pet = models.ForeignKey(Pet, blank=True, null=True)
-
-    field_history = FieldHistoryTracker(['pet'])
-
-
 class Person(models.Model):
     name = models.CharField(max_length=255)
     created_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True)
@@ -24,6 +17,12 @@ class Person(models.Model):
     @property
     def _field_history_user(self):
         return self.created_by
+
+
+class Owner(Person):
+    pet = models.ForeignKey(Pet, blank=True, null=True)
+
+    field_history = FieldHistoryTracker(['name', 'pet'])
 
 
 class Human(models.Model):


### PR DESCRIPTION
- made migration compatible with Django 1.7, added index on field_name column
- ability to change serialize name in settings: FIELD_HISTORY_SERIALIZER_NAME
- added json_nested_serializer for serializing fields from parent model