### PR TITLE
Added inheritance from django.utils.deprecation.MiddlewareMixin to co…

### DIFF
--- a/field_history/middleware.py
+++ b/field_history/middleware.py
@@ -1,7 +1,8 @@
 from .tracker import FieldHistoryTracker
+from django.utils.deprecation import MiddlewareMixin
 
 
-class FieldHistoryMiddleware(object):
+class FieldHistoryMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         FieldHistoryTracker.thread.request = request


### PR DESCRIPTION
Correct incompatibility with Django 1.10

Django 1.10 changed MIDDLEWARE_CLASSES to MIDDLEWARE. This patch adjusts for that.