### PR TITLE
Fix Django 1.10 Middleware compatibility

### DIFF
--- a/field_history/middleware.py
+++ b/field_history/middleware.py
@@ -1,8 +1,16 @@
 from .tracker import FieldHistoryTracker
-from django.utils.deprecation import MiddlewareMixin
+from django import VERSION
 
 
-class FieldHistoryMiddleware(MiddlewareMixin):
+if VERSION >= (1, 10):
+    from django.utils.deprecation import MiddlewareMixin
 
-    def process_request(self, request):
-        FieldHistoryTracker.thread.request = request
+    class FieldHistoryMiddleware(MiddlewareMixin):
+
+        def process_request(self, request):
+            FieldHistoryTracker.thread.request = request
+else:
+    class FieldHistoryMiddleware(object):
+
+        def process_request(self, request):
+            FieldHistoryTracker.thread.request = request

--- a/field_history/middleware.py
+++ b/field_history/middleware.py
@@ -1,7 +1,8 @@
 from .tracker import FieldHistoryTracker
+from django.utils.deprecation import MiddlewareMixin
 
 
-class FieldHistoryMiddleware(object):
+class FieldHistoryMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         FieldHistoryTracker.thread.request = request


### PR DESCRIPTION
This is a fix for issue #12 

Adds inheritance from django.utils.deprecation.MiddlewareMixin when using Django >= 1.10