### PR TITLE
Provide setting to override object_id type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,6 +172,28 @@ Alternatively, you can add a ``_field_history_user`` property to the model that 
         def _field_history_user(self):
             return self.updated_by
 
+Working with MySQL
+------------------
+
+If you're using MySQL, the default configuration will throw an exception when you run migrations. (By default, ``FieldHistory.object_id`` is implemented as a ``TextField`` for flexibility, but indexed columns in MySQL InnoDB tables may be a maximum of 767 bytes.) To fix this, you can set ``FIELD_HISTORY_OBJECT_ID_TYPE`` in settings.py to override the default field type with one that meets MySQL's constraints. ``FIELD_HISTORY_OBJECT_ID_TYPE`` may be set to either:
+
+1. the Django model field class you wish to use, or
+2. a tuple ``(field_class, kwargs)``, where ``field_class`` is a Django model field class and ``kwargs`` is a dict of arguments to pass to the field class constructor.
+
+To approximate the default behavior for Postgres when using MySQL, configure ``object_id`` to use a ``CharField`` by adding the following to settings.py:
+
+.. code-block:: python
+
+    from django.db import models
+    FIELD_HISTORY_OBJECT_ID_TYPE = (models.CharField, {'max_length': 100})
+
+``FIELD_HISTORY_OBJECT_ID_TYPE`` also allows you to use a field type that's more efficient for your use case, even if you're using Postgres (or a similarly unconstrained database). For example, if you always let Django auto-create an ``id`` field (implemented internally as an ``AutoField``), setting ``FIELD_HISTORY_OBJECT_ID_TYPE`` to ``IntegerField`` will result in efficiency gains (both in time and space). This would look like:
+
+.. code-block:: python
+
+    from django.db import models
+    FIELD_HISTORY_OBJECT_ID_TYPE = models.IntegerField
+
 Running Tests
 -------------
 

--- a/field_history/migrations/0001_initial.py
+++ b/field_history/migrations/0001_initial.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 
+from field_history.models import OBJECT_ID_TYPE_SETTING, instantiate_object_id_field
+
 
 class Migration(migrations.Migration):
 
@@ -21,7 +23,7 @@ class Migration(migrations.Migration):
             name='FieldHistory',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('object_id', models.TextField(db_index=True)),
+                ('object_id', instantiate_object_id_field(getattr(settings, OBJECT_ID_TYPE_SETTING, models.TextField))),
                 ('field_name', models.CharField(max_length=500)),
                 ('serialized_data', models.TextField()),
                 ('date_created', models.DateTimeField(auto_now_add=True, db_index=True)),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,10 +5,11 @@ import datetime
 from django.contrib.auth import get_user_model
 from django.core.management import CommandError, call_command
 from django.core.urlresolvers import reverse
+from django.db import models
 from django.test.utils import override_settings
 from django.test import TestCase
 from django.utils import six
-from field_history.models import FieldHistory
+from field_history.models import FieldHistory, instantiate_object_id_field
 
 from .models import Human, Owner, Person, Pet, PizzaOrder
 
@@ -270,6 +271,22 @@ class FieldHistoryTests(TestCase):
         self.assertEqual(history.object, owner)
         self.assertEqual(history.field_name, 'name')
         self.assertEqual(history.field_value, 'Jon')
+
+    def test_object_id_field_type_class(self):
+        field = instantiate_object_id_field(models.PositiveIntegerField)
+        self.assertIsInstance(field, models.PositiveIntegerField)
+
+    def test_object_id_field_type_tuple(self):
+        field = instantiate_object_id_field((models.CharField, {'max_length': 20}))
+        self.assertIsInstance(field, models.CharField)
+        self.assertEqual(field.max_length, 20)
+
+    def test_object_id_field_type_requires_field_class(self):
+        self.assertRaises(TypeError, lambda: instantiate_object_id_field(int))
+
+    def test_object_id_field_type_requires_kwargs_as_dict(self):
+        object_id_tuple_bad_kwargs = (models.TextField, 10)
+        self.assertRaises(TypeError, lambda: instantiate_object_id_field(object_id_tuple_bad_kwargs))
 
 
 class ManagementCommandsTests(TestCase):


### PR DESCRIPTION
Implements a complete solution to #16 by adding a setting to override the field type of ``FieldHistory.object_id``. Preserves ``TextField`` as the default field type for backwards compatibility.

See updates to README.rst for more details.