### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ django-field-history
     :target: https://badge.fury.io/py/django-field-history
 
 .. image:: https://readthedocs.org/projects/django-field-history/badge/?version=latest
-    :target: http://django-field-history.readthedocs.org/en/latest/?badge=latest
+    :target: https://django-field-history.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 .. image:: https://travis-ci.org/grantmcconnaughey/django-field-history.svg?branch=master
@@ -20,7 +20,7 @@ A Django app to track changes to a model field. For Python 2.7/3.2+ and Django 1
 Documentation
 -------------
 
-The full documentation is at https://django-field-history.readthedocs.org.
+The full documentation is at https://django-field-history.readthedocs.io.
 
 Features
 --------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.