### PR TITLE
pluralize FieldHistory model to 'Field histories'

### DIFF
--- a/field_history/models.py
+++ b/field_history/models.py
@@ -50,6 +50,7 @@ class FieldHistory(models.Model):
     class Meta:
         app_label = 'field_history'
         get_latest_by = 'date_created'
+        verbose_name_plural = 'Field histories'
 
     def __str__(self):
         return u'{} field history for {}'.format(self.field_name, self.object)


### PR DESCRIPTION
Currently the FieldHistory model shows up in the admin as 'Field historys', so this changes it to 'Field histories'