### PR TITLE
FIELD_HISTORY_OBJECT_ID_TYPE not working with django-configurations

### DIFF
--- a/field_history/models.py
+++ b/field_history/models.py
@@ -27,6 +27,9 @@ def instantiate_object_id_field(object_id_class_or_tuple=models.TextField):
         object_id_class = object_id_class_or_tuple
         object_id_kwargs = {}
 
+    if type(object_id_class) is not type and type(object_id_class.__class__) is type:
+        object_id_class = object_id_class.__class__
+
     if not issubclass(object_id_class, models.fields.Field):
         raise TypeError('settings.%s must be a Django model field or (field, kwargs) tuple' % OBJECT_ID_TYPE_SETTING)
     if not isinstance(object_id_kwargs, dict):


### PR DESCRIPTION
I'm not certain if this was exclusive to django-configurations, but setting FIELD_HISTORY_OBJECT_ID_TYPE = models.IntegerField caused it to error out because an instance of the class was being passed, not the class itself. This hotfix checks to see if that's what's being passed first and converts it back to the class if that's the case.