### PR TITLE
Add post_field_history_bulk_create signal

### DIFF
--- a/field_history/signals.py
+++ b/field_history/signals.py
@@ -1,0 +1,5 @@
+import django.dispatch
+
+
+post_field_history_bulk_create = django.dispatch.Signal(
+	providing_args=['tracked_instance', 'field_history_instances'])

--- a/field_history/tracker.py
+++ b/field_history/tracker.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.utils.functional import curry
 
 from .models import FieldHistory
+from .signals import post_field_history_bulk_create
 
 
 def get_serializer_name():
@@ -111,7 +112,13 @@ class FieldHistoryTracker(object):
 
             if field_histories:
                 # Create all the FieldHistory objects in one batch
-                FieldHistory.objects.bulk_create(field_histories)
+                field_history_instances = \
+                    FieldHistory.objects.bulk_create(field_histories)
+                post_field_history_bulk_create.send(
+                    sender=FieldHistory,
+                    tracked_instance=instance,
+                    field_history_instances=field_history_instances
+                )
 
             # Update tracker in case this model is saved again
             self._inititalize_tracker(instance)


### PR DESCRIPTION
I needed a way to have a "post_save" signal that was triggered after FieldHistory instances where created. This implementation is working fine for what I needed.

I have to note thou that this will only work with postgres as other database connections do not return the list of instances after bulk_create. I created this pull request more as a conversation starter than an actual pull request.

https://github.com/django/django/blob/330638b89f14e1fb06e9d313ccc9768ae167c53f/django/db/models/query.py#L483